### PR TITLE
Logic for Jupyter in Anaconda

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
     "babel-cli": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "electron": "^1.7.4",
-    "electron-builder": "^19.16.1"
+    "electron-builder": "^19.56.2"
   },
   "dependencies": {
     "auto-launch": "^5.0.1",
     "electron-store": "^1.2.0",
-    "electron-updater": "^2.7.1",
+    "electron-updater": "^2.18.2",
     "jimp": "^0.2.28",
     "locate-executable": "^1.1.0",
     "mkdirp": "^0.5.1"

--- a/src/ensureJupyter.js
+++ b/src/ensureJupyter.js
@@ -10,7 +10,16 @@ const ensureJupyter = callback => {
     locateExecutable('jupyter', (err, paths) => {
         if (err) return throwError(...R.ERR_LOCEXE(err))
 
-        if (paths.length === 0) return throwError(...R.ERR_ENOENT)
+        if (paths.length === 0) {
+            var which = require('which')
+            var resolved = which.sync('jupyter', {nothrow: true})
+            if (resolved !== null) {
+                paths.push(resolved)
+            }
+            else {
+                return throwError(...R.ERR_ENOENT)
+            }
+        }
 
         config.set('jupyter', paths[0])
         callback()


### PR DESCRIPTION
Added logic to prevent 'Do you have Jupyter Notebook installed?' when… Jupyter is installed via Anaconda (v1.9.2) in macOS 10.13.6